### PR TITLE
Update to F3D master and reduce binary size

### DIFF
--- a/f3d/libs/f3d.jar
+++ b/f3d/libs/f3d.jar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5012019c6bcb9c884eab35095ccfaa3905108818d141304e3d098bfaa39aa57a
+oid sha256:7e97908a6a83cc538728d159a4980f6eba031d23b2c43c20a1a04dad58057e92
 size 31576

--- a/f3d/src/main/jniLibs/arm64-v8a/libf3d-java.so
+++ b/f3d/src/main/jniLibs/arm64-v8a/libf3d-java.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c658f5c7d94281740a398092ae897e16129ba1bdee68db9f39b8e00553902a83
-size 106781576
+oid sha256:d1de17a2cf370ac8fa2f831cfbb9c1cc6b64db8612f96d666bf3a074e0514573
+size 76648480

--- a/f3d/src/main/jniLibs/armeabi-v7a/libf3d-java.so
+++ b/f3d/src/main/jniLibs/armeabi-v7a/libf3d-java.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f8ce024650a44e646a7c62a37406e865edb9d0f013c1dfebfd7c9c56fa9aa139
-size 83496840
+oid sha256:26a0f437c28925bfd84fca09c188c66164a5e7909d3009c201b2b3dcc693c9dc
+size 53817760

--- a/f3d/src/main/jniLibs/x86/libf3d-java.so
+++ b/f3d/src/main/jniLibs/x86/libf3d-java.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:81ead849620bc87469880bdba42bc112d50a79c2d80700dc00a47561df89b9e0
-size 102656440
+oid sha256:d752a15b1f1bcdf980351e4860ddca848775c9004999b3e66d8bac78ab43cab3
+size 82248296

--- a/f3d/src/main/jniLibs/x86_64/libf3d-java.so
+++ b/f3d/src/main/jniLibs/x86_64/libf3d-java.so
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:cda58db3990bafecacd714209f34ee3f4851c7acdbc5c462c3e5a3d84ad7f3d7
-size 104175312
+oid sha256:92533fdf70ad5081d84ae4a22f29a1eb919e85cb5230e5b8ecfd81cb3bfc5fcc
+size 81324184

--- a/update_native_libs.sh
+++ b/update_native_libs.sh
@@ -125,6 +125,7 @@ for arch in "${ARCHS[@]}"; do
     echo "========================================"
 
     CONFIG_CMD="cmake -S /src -B /src/build-${arch} \
+        -DCMAKE_BUILD_TYPE=Release \
         -DF3D_MODULE_EXR=ON \
         -DF3D_MODULE_UI=OFF \
         -DF3D_MODULE_WEBP=ON \
@@ -140,12 +141,14 @@ for arch in "${ARCHS[@]}"; do
 
     BUILD_CMD="cmake --build /src/build-${arch}"
 
+    STRIP_CMD="/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all /src/build-${arch}/lib/libf3d-java.so"
+
     docker run --rm -it \
         -e CMAKE_BUILD_PARALLEL_LEVEL \
         -u "$(id -u):$(id -g)" \
         -v "$CLONE_DIR":/src \
         "ghcr.io/f3d-app/f3d-android-${arch}" \
-        sh -c "$CONFIG_CMD && $BUILD_CMD"
+        sh -c "$CONFIG_CMD && $BUILD_CMD && $STRIP_CMD"
 
     # Copy .so into the Android project
     SO_SRC="$CLONE_DIR/build-${arch}/lib/libf3d-java.so"


### PR DESCRIPTION
- Strip library to reduce its size by ~30%
- Make sure the native libs are Release builds
- Update native libs to F3D master for full streaming support