### PR TITLE
Don't use -it docker options

### DIFF
--- a/update_native_libs.sh
+++ b/update_native_libs.sh
@@ -183,7 +183,7 @@ for arch in "${ARCHS[@]}"; do
 
     STRIP_CMD="/ndk/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-strip --strip-all /src/build-${arch}/lib/libf3d-java.so"
 
-    docker run --rm -it \
+    docker run --rm \
         -e CMAKE_BUILD_PARALLEL_LEVEL \
         -u "$(id -u):$(id -g)" \
         -v "$CLONE_DIR":/src \


### PR DESCRIPTION
- `-i` keeps stdin open, which is not needed
- `-t` allocates a TTY for proper output coloring, which causes issues in CI sometimes