### PR TITLE
Fix crash with Android 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         profile: [small_phone, medium_phone, medium_tablet, desktop_large]
+        api: [28, 36]
 
     steps:
       - name: Checkout
@@ -74,7 +75,7 @@ jobs:
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 28
+          api-level: ${{ matrix.api }}
           arch: x86_64
           profile: ${{ matrix.profile }}
           emulator-options: -no-window -gpu lavapipe -no-snapshot -noaudio -no-boot-anim

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Use the Gradle wrapper to run the tests:
 ```
 
 > [!WARNING]
-> Some tests does image comparison and requires a specific device resolution. Currently, it's only tested on the following emulated devices:
+> Some tests does image comparison and requires a specific device resolution. Currently, it's only tested on api levels 28 and 36 and with the following emulated devices:
 > - small_phone
 > - medium_phone
 > - medium_tablet

--- a/f3d/src/androidTest/assets/baselines/testOpen_1080x2400.png
+++ b/f3d/src/androidTest/assets/baselines/testOpen_1080x2400.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0256726ac28ff5cf53d771a52f9b2d6d42fa069c743a2926b7f5bebf6f43ae51
+size 53169

--- a/f3d/src/androidTest/assets/baselines/testOpen_1920x1080.png
+++ b/f3d/src/androidTest/assets/baselines/testOpen_1920x1080.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2cb742a116a5c19bd10ce04f93c571e8b2018faaec19ac6d790d2166117bda64
+size 106355

--- a/f3d/src/androidTest/assets/baselines/testOpen_2560x1600.png
+++ b/f3d/src/androidTest/assets/baselines/testOpen_2560x1600.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cc9974cd5eee8dbefd89df04380b0664757a468cf79d6b12097c340e3f1049e4
+size 195288

--- a/f3d/src/androidTest/assets/baselines/testOpen_720x1280.png
+++ b/f3d/src/androidTest/assets/baselines/testOpen_720x1280.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6cd95b6c5806f0227d2ad0b08236ad8a9f0f8f5f42b8a0aa7127d59a57ac71a
+size 34924

--- a/f3d/src/androidTest/assets/baselines/testRotateAndResume_1080x2400.png
+++ b/f3d/src/androidTest/assets/baselines/testRotateAndResume_1080x2400.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e0064ad7649713993e468de89c2254bbdd6e87cbcee8316c92e1fae91bf579fc
+size 52792

--- a/f3d/src/androidTest/assets/baselines/testRotateAndResume_1920x1080.png
+++ b/f3d/src/androidTest/assets/baselines/testRotateAndResume_1920x1080.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5ad5860e0c85046dcf19d06807d88eb96ef2bdf720530d45cdb060601f6450a
+size 94556

--- a/f3d/src/androidTest/assets/baselines/testRotateAndResume_2560x1600.png
+++ b/f3d/src/androidTest/assets/baselines/testRotateAndResume_2560x1600.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d119ae45984c68cf2f176e56dfa8fe2aadd225ecf13c5a0953d2498e6faeee1
+size 176446

--- a/f3d/src/androidTest/assets/baselines/testRotateAndResume_720x1280.png
+++ b/f3d/src/androidTest/assets/baselines/testRotateAndResume_720x1280.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d92f55e2da6183833dcc0c6e076c6353efd7ad9d8fd1e96f0c7986ef941d552
+size 34202

--- a/f3d/src/main/java/app/f3d/F3D/android/MainActivity.kt
+++ b/f3d/src/main/java/app/f3d/F3D/android/MainActivity.kt
@@ -4,14 +4,11 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import android.view.View
-import androidx.activity.result.ActivityResultCallback
 import androidx.activity.result.ActivityResultLauncher
-import androidx.appcompat.app.ActionBar
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintLayout
 import app.f3d.F3D.android.Utils.FileInteractionContract
 import com.google.android.material.floatingactionbutton.FloatingActionButton
-import java.util.Objects
 
 class MainActivity : AppCompatActivity() {
     private var mView: MainView? = null
@@ -31,13 +28,13 @@ class MainActivity : AppCompatActivity() {
 
         handleSelectedFileAppNotOpen()
 
-        fileInteractionLauncher = registerForActivityResult<Void?, Uri?>(
-            FileInteractionContract(),
-            ActivityResultCallback { uri: Uri? -> this.handleSelectedFile(uri) })
+        fileInteractionLauncher = registerForActivityResult(
+            FileInteractionContract()
+        ) { uri: Uri? -> this.handleSelectedFile(uri) }
 
-        addButton.setOnClickListener(View.OnClickListener { view: View? ->
+        addButton.setOnClickListener { _: View? ->
             fileInteractionLauncher!!.launch(null)
-        })
+        }
 
         mainLayout.addView(mView)
     }

--- a/f3d/src/main/java/app/f3d/F3D/android/MainView.kt
+++ b/f3d/src/main/java/app/f3d/F3D/android/MainView.kt
@@ -176,10 +176,12 @@ class MainView(context: Context) : GLSurfaceView(context) {
     // forward events to rendering thread for it to handle
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent): Boolean {
+        val eventCopy = MotionEvent.obtain(event)
         queueEvent {
-            mPanDetector.onTouchEvent(event)
-            mScaleDetector.onTouchEvent(event)
-            mRotateDetector.onTouchEvent(event)
+            mPanDetector.onTouchEvent(eventCopy)
+            mScaleDetector.onTouchEvent(eventCopy)
+            mRotateDetector.onTouchEvent(eventCopy)
+            eventCopy.recycle()
         }
 
         return true

--- a/f3d/src/main/java/app/f3d/F3D/android/PanGestureDetector.kt
+++ b/f3d/src/main/java/app/f3d/F3D/android/PanGestureDetector.kt
@@ -73,7 +73,7 @@ class PanGestureDetector(private val mGestureListener: OnPanGestureListener) {
                 mPreviousLine = currentLine
             }
 
-            MotionEvent.ACTION_UP -> {
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                 mPointerId1 = INVALID_POINTER_ID
                 mPointerId2 = INVALID_POINTER_ID
             }

--- a/f3d/src/main/java/app/f3d/F3D/android/RotateGestureDetector.kt
+++ b/f3d/src/main/java/app/f3d/F3D/android/RotateGestureDetector.kt
@@ -56,7 +56,7 @@ class RotateGestureDetector(private val mGestureListener: OnRotateGestureListene
             MotionEvent.ACTION_MOVE -> {
                 if (mPointerId != INVALID_POINTER_ID) {
                     val pointerIndex = event.findPointerIndex(mPointerId)
-                    if (pointerIndex < 0) return
+                    if (pointerIndex < 0) { return }
 
                     val x = event.getX(pointerIndex)
                     val y = event.getY(pointerIndex)

--- a/f3d/src/main/java/app/f3d/F3D/android/RotateGestureDetector.kt
+++ b/f3d/src/main/java/app/f3d/F3D/android/RotateGestureDetector.kt
@@ -41,11 +41,11 @@ class RotateGestureDetector(private val mGestureListener: OnRotateGestureListene
      * @param event The motion event that occurred.
      */
     fun onTouchEvent(event: MotionEvent) {
-        when (event.getActionMasked()) {
+        when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
-                mPointerId = event.getPointerId(event.getActionIndex())
-                mLastTouchX = event.getX()
-                mLastTouchY = event.getY()
+                mPointerId = event.getPointerId(event.actionIndex)
+                mLastTouchX = event.x
+                mLastTouchY = event.y
             }
 
             MotionEvent.ACTION_POINTER_DOWN -> {
@@ -55,8 +55,11 @@ class RotateGestureDetector(private val mGestureListener: OnRotateGestureListene
 
             MotionEvent.ACTION_MOVE -> {
                 if (mPointerId != INVALID_POINTER_ID) {
-                    val x = event.getX()
-                    val y = event.getY()
+                    val pointerIndex = event.findPointerIndex(mPointerId)
+                    if (pointerIndex < 0) return
+
+                    val x = event.getX(pointerIndex)
+                    val y = event.getY(pointerIndex)
 
                     // Calculate the distance moved
                     this.distanceX = x - mLastTouchX
@@ -67,6 +70,10 @@ class RotateGestureDetector(private val mGestureListener: OnRotateGestureListene
 
                     mGestureListener.onRotate(this)
                 }
+            }
+
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                mPointerId = INVALID_POINTER_ID
             }
         }
     }
@@ -86,6 +93,6 @@ class RotateGestureDetector(private val mGestureListener: OnRotateGestureListene
     }
 
     companion object {
-        private val INVALID_POINTER_ID = -1
+        private const val INVALID_POINTER_ID = -1
     }
 }


### PR DESCRIPTION
Fix crash with Android 16.
I've reproduced #50 with the Android emulator when API level 36 is used (Android 16).
This changes fixes the crash on my side and add CI to test with the last Android latest Android version (and keep the min version to 28)